### PR TITLE
Add the option to disable the 'Go to Symbol' feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,11 @@
           },
           "default": [],
           "description": "Additional arguments to pass to luacheck"
+        },
+        "lua.symbol.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Specifies whether to enable the 'Go to symbol' feature."
         }
       }
     }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -39,12 +39,17 @@ export interface LintingOptions {
     luaCheckArgs: string[];
 }
 
+export interface SymbolOptions {
+    enabled: boolean;
+}
+
 export interface Settings {
     luacheckPath: string;
     preferLuaCheckErrors: boolean;
     targetVersion: string;
     format: FormatOptions;
     linting: LintingOptions;
+    symbol: SymbolOptions;
 }
 
 class ServiceDispatcher {
@@ -97,6 +102,10 @@ class ServiceDispatcher {
     }
 
     private onDocumentSymbol(handler: DocumentSymbolParams): SymbolInformation[] {
+        if (!this.settings.symbol.enabled) {
+            return [];
+        }
+
         const uri = handler.textDocument.uri;
         const analysis: Analysis.Analysis = this.perDocumentAnalysis[uri];
 
@@ -104,7 +113,7 @@ class ServiceDispatcher {
     }
 
     private onWorkspaceSymbol(handler: WorkspaceSymbolParams) {
-        if (!this.rootUri) {
+        if (!this.rootUri || !this.settings.symbol.enabled) {
             return [];
         }
 
@@ -230,6 +239,7 @@ class ServiceDispatcher {
         this.settings.format.singleQuote = validateSetting<boolean>(this.settings.format.singleQuote, false);
         this.settings.format.linebreakMultipleAssignments = validateSetting<boolean>(
             this.settings.format.linebreakMultipleAssignments, false);
+        this.settings.symbol.enabled = validateSetting<boolean>(this.settings.symbol.enabled, true);
 
         // Validate the version. onDidChangeConfiguration seems to be called for every keystroke the user enters,
         // so its possible that the version string will be malformed.


### PR DESCRIPTION
![image](https://github.com/trixnz/vscode-lua/assets/11395055/7f2f0fd4-0281-4a5e-bac3-c93091caa9b6)


Disabling the "Go to Symbol" feature is useful for those who use this extension together with the [lua-language-server](https://github.com/LuaLS/lua-language-server), because currently it is causing an issue which the methods are appearing twice:

![image](https://github.com/trixnz/vscode-lua/assets/11395055/e63448a6-28c7-4f7a-b3fb-fb32228b1c3a)

